### PR TITLE
Initial DNS SRV support to find WHOIS servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ validators = "0.22"
 serde_json = "1"
 once_cell = "1"
 regex = "1"
+trust-dns-client = "0.20.3"
 
 tokio = { version = "1", features = ["fs", "net", "time", "io-util"], optional = true }
 

--- a/src/who_is.rs
+++ b/src/who_is.rs
@@ -153,13 +153,11 @@ impl WhoIs {
             let answers: &[Record] = response.answers();
             for record in answers {
                 if let RData::SRV(record) = record.rdata() {
-                    println!("{} {}", record.target(), record.port());
                     let target = record.target().to_string();
                     let new_server = match WhoIsServerValue::from_string(&target[..target.len()-1]) {
                         Ok(new_server) => new_server,
                         Err(_error) => continue,
                     };
-                    println!("Ohhhhh");
                     self.map.insert(tld.to_string(), new_server);
                     return true;
                 }

--- a/src/who_is.rs
+++ b/src/who_is.rs
@@ -9,6 +9,12 @@ use std::time::Duration;
 
 use std::fs::File;
 
+use trust_dns_client::client::{Client, SyncClient};
+use trust_dns_client::udp::UdpClientConnection;
+use std::str::FromStr;
+use trust_dns_client::op::DnsResponse;
+use trust_dns_client::rr::{DNSClass, Name, RData, Record, RecordType};
+
 #[cfg(feature = "tokio")]
 use crate::tokio;
 
@@ -38,6 +44,13 @@ pub struct WhoIs {
 }
 
 impl WhoIs {
+    pub fn from_host<T: AsRef<str>>(host: T) -> Result<WhoIs, WhoIsError>{
+        Ok(Self {
+            map: HashMap::new(),
+            ip: WhoIsServerValue::from_string(host)?,
+        })
+    }
+
     /// Read the list of WHOIS servers (JSON data) from a file to create a `WhoIs` instance.
     #[inline]
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<WhoIs, WhoIsError> {
@@ -115,6 +128,46 @@ impl WhoIs {
 }
 
 impl WhoIs {
+    pub fn can_find_server_for_tld(&mut self, mut tld: &str) -> bool {
+        let address = "8.8.8.8:53".parse().unwrap();
+        let conn = UdpClientConnection::new(address).unwrap();
+        let client = SyncClient::new(conn);
+        loop {
+            if self.map.contains_key(tld) {
+                break;
+            }
+            match tld.find('.') {
+                Some(index) => {
+                    tld = &tld[index + 1..];
+                }
+                None => {
+                    tld = "";
+                }
+            }
+            if tld.is_empty() {
+                break;
+            }
+            println!("TLD: {}", tld);
+            let name = Name::from_str(&format!("_nicname._tcp.{}.", tld)).unwrap();
+            let response: DnsResponse = client.query(&name, DNSClass::IN, RecordType::SRV).unwrap();
+            let answers: &[Record] = response.answers();
+            for record in answers {
+                if let RData::SRV(record) = record.rdata() {
+                    println!("{} {}", record.target(), record.port());
+                    let target = record.target().to_string();
+                    let new_server = match WhoIsServerValue::from_string(&target[..target.len()-1]) {
+                        Ok(new_server) => new_server,
+                        Err(_error) => continue,
+                    };
+                    println!("Ohhhhh");
+                    self.map.insert(tld.to_string(), new_server);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     fn get_server_by_tld(&self, mut tld: &str) -> Option<&WhoIsServerValue> {
         let mut server;
 

--- a/src/who_is.rs
+++ b/src/who_is.rs
@@ -128,8 +128,8 @@ impl WhoIs {
 }
 
 impl WhoIs {
-    pub fn can_find_server_for_tld(&mut self, mut tld: &str) -> bool {
-        let address = "8.8.8.8:53".parse().unwrap();
+    pub fn can_find_server_for_tld(&mut self, mut tld: &str, dns_server: &str) -> bool {
+        let address = dns_server.parse().unwrap();
         let conn = UdpClientConnection::new(address).unwrap();
         let client = SyncClient::new(conn);
         loop {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,6 +18,22 @@ fn test() {
     println!("{}", result);
 }
 
+#[test]
+fn test_srv() {
+    let mut who = WhoIs::from_host("whois.arin.net").unwrap();
+    who.can_find_server_for_tld(".lotteryusa.us");
+
+    let result = who.lookup(WhoIsLookupOptions::from_string("lotteryusa.us").unwrap()).unwrap();
+    println!("{}", result);
+
+    let result = who.lookup(WhoIsLookupOptions::from_string("66.42.43.17").unwrap()).unwrap();
+    println!("{}", result);
+
+    let result =
+        who.lookup(WhoIsLookupOptions::from_string("fe80::5400:1ff:feaf:b71").unwrap()).unwrap();
+    println!("{}", result);
+}
+
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn test_async() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,7 +21,7 @@ fn test() {
 #[test]
 fn test_srv() {
     let mut who = WhoIs::from_host("whois.arin.net").unwrap();
-    who.can_find_server_for_tld(".lotteryusa.us");
+    who.can_find_server_for_tld(".lotteryusa.us", "8.8.8.8:53");
 
     let result = who.lookup(WhoIsLookupOptions::from_string("lotteryusa.us").unwrap()).unwrap();
     println!("{}", result);


### PR DESCRIPTION
WHOIS servers can be find using [DNS SRV records](http://circleid.com/posts/whois_server_address_registry).