### PR TITLE
Remove [ ] from around IPv6 addresses so whois works on them

### DIFF
--- a/src/who_is.rs
+++ b/src/who_is.rs
@@ -292,9 +292,20 @@ impl WhoIs {
                     None => &self.ip,
                 };
 
+                // Remove [ ] wrapper around IPv6 addresses, which is added by to_uri_authority_string()
+                // at https://github.com/magiclen/validators/blob/953b61fdfcad45cda128cef71d91bec5a1207642/validators-derive/src/validator_handlers/ipv6.rs#L323
+                let target = options.target.to_uri_authority_string();
+                //eprintln!("target={}", target);
+                let re = Regex::new(r"^\[(.+)\]$").unwrap();
+                let bare_ip_string = match re.captures(&target) {
+                    Some(target) => target.get(1).unwrap().as_str().to_string(),
+                    None => target.to_string(),
+                };
+                //eprintln!("bare_ip_string={}", bare_ip_string);
+
                 Self::lookup_inner(
                     server,
-                    options.target.to_uri_authority_string().as_ref(),
+                    &bare_ip_string,
                     options.timeout,
                     options.follow,
                 )


### PR DESCRIPTION
This is a quick hack to work around a problem I ran into when using whois for simple IP address lookups. You probably don't want to accept this, but this illustrates the problem.

With the demo config from the docs:

```json
    "_": {
        "ip": {
            "host": "whois.arin.net",
            "query": "n + $addr\r\n"
        }
    }
```

IPv4 lookups work fine, but IPv6 lookups get this error, for example on `2600:3c00::`:

```
No match found for n + [2600:3c00::].
```

I found that the IPv6 address was being wrapped in `[` and `]` which caused the problem, and this quick hack to strip them works.

It would be nicer to omit the `[` and `]` from the beginning since we don't want them, but I imagine that would break other users of the `validators` crate.

Perhaps there should be an option to have `validators` emit IPv6 with no `[` and `]`? I'd be willing to try to implement that if you think that makes sense.