### PR TITLE
Fix Non UTF-8 Responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ regex = "1"
 trust-dns-client = "0.23"
 
 tokio = { version = "1", features = ["fs", "net", "time", "io-util"], optional = true }
+encoding_rs = "0.8.34"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src/who_is.rs
+++ b/src/who_is.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use encoding_rs::{ISO_8859_2, UTF_8, WINDOWS_1252};
+use encoding_rs::{UTF_8, WINDOWS_1252};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_json::{Map, Value};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,6 +21,17 @@ fn test_srv() {
     println!("{}", result);
 }
 
+#[test]
+fn test_non_utf8_responses() {
+    let who = WhoIs::from_host("whois.arin.net").unwrap();
+    
+    let result = who.lookup(WhoIsLookupOptions::from_string("178.202.0.0").unwrap()).unwrap();
+    println!("{}", result);
+
+    let result = who.lookup(WhoIsLookupOptions::from_string("185.73.124.0").unwrap()).unwrap();
+    println!("{}", result);
+}
+
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn test_async() {


### PR DESCRIPTION
### Add ISO-8859-1/Windows-1252 support using encoding_rs

tries UTF-8, and then ISO-8859-1
if both fail defaults to String::from_utf8_lossy

fixes [Errors on specific IP addresses](https://github.com/magiclen/whois-rust/issues/3)